### PR TITLE
Add descriptive link for strangers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pittsburgh Patchworks
 
+Pittsburgh edition of the [GitHub Patchwork program](http://patchwork.github.io/).
+
 ## :calendar: Date :calendar: ##
 August 7th
 In conjunction with: Code and Supply Meetup and GDI.


### PR DESCRIPTION
If I tag someone unfamiliar with what we're doing, they'll likely look at the README